### PR TITLE
Arrow key functionality added to camera position + Reset camera position button

### DIFF
--- a/version_desktop/project.godot
+++ b/version_desktop/project.godot
@@ -29,6 +29,37 @@ window/subwindows/embed_subwindows=false
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
+[input]
+
+ui_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
+]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
+]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
+]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
+]
+}
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/version_desktop/src/ui/workspace/canvas_panel_container.tscn
+++ b/version_desktop/src/ui/workspace/canvas_panel_container.tscn
@@ -29,6 +29,12 @@ size_flags_horizontal = 8
 size_flags_vertical = 0
 alignment = 2
 
+[node name="ResetPositionButton" type="Button" parent="VBoxContainer/ZoomMarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(30, 30)
+layout_mode = 2
+text = "Reset"
+icon_alignment = 1
+
 [node name="ZoomInButton" type="Button" parent="VBoxContainer/ZoomMarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
@@ -151,6 +157,7 @@ layout_mode = 2
 text = "Redo"
 script = ExtResource("4_6sua3")
 
+[connection signal="pressed" from="VBoxContainer/ZoomMarginContainer/HBoxContainer/ResetPositionButton" to="VBoxContainer/CanvasViewMarginContainer" method="_on_reset_position_button_pressed"]
 [connection signal="value_changed" from="VBoxContainer/CanvasViewMarginContainer/HBoxContainer/VBoxContainer/HScrollBar" to="VBoxContainer/CanvasViewMarginContainer" method="_on_h_scroll_bar_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/CanvasViewMarginContainer/HBoxContainer/VBoxContainer2/VScrollBar" to="VBoxContainer/CanvasViewMarginContainer" method="_on_v_scroll_bar_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/OptionsMarginContainer/HBoxContainer/CanvasSizeHBoxContainer/XSpinBox" to="VBoxContainer/OptionsMarginContainer/HBoxContainer/CanvasSizeHBoxContainer/XSpinBox" method="_on_value_changed"]

--- a/version_desktop/src/ui/workspace/canvasviewmargincontainer.gd
+++ b/version_desktop/src/ui/workspace/canvasviewmargincontainer.gd
@@ -66,3 +66,34 @@ func _on_h_scroll_bar_value_changed(value):
 ## modify camera offset.y based on scroll
 func _on_v_scroll_bar_value_changed(value):
 	canvas_camera_node.offset.y = value 
+	
+func _input(event):
+	if hscrollbar.visible == true and vscrollbar.visible == true and event is InputEventKey and !Input.is_key_pressed(KEY_CTRL):
+		## Shift + arrow key resets camera position on the axis of the key
+		if Input.is_key_pressed(KEY_SHIFT):
+			if Input.is_key_pressed(KEY_LEFT):
+				hscrollbar.value = 0
+			if Input.is_key_pressed(KEY_RIGHT):
+				hscrollbar.value = 0
+			if Input.is_key_pressed(KEY_UP):
+				vscrollbar.value = 0
+			if Input.is_key_pressed(KEY_DOWN):
+				vscrollbar.value = 0
+		## Arrows keys move camera position
+		else:
+			if Input.is_key_pressed(KEY_LEFT):
+				hscrollbar.value -= 5
+			if Input.is_key_pressed(KEY_RIGHT):
+				hscrollbar.value += 5
+			if Input.is_key_pressed(KEY_UP):
+				vscrollbar.value -= 5
+			if Input.is_key_pressed(KEY_DOWN):
+				vscrollbar.value += 5
+
+## Reset position (implicitly signals scroll bars to reset
+func _on_reset_position_button_pressed():
+	canvas_camera_node.camera_zoom = Vector2(1,1)
+	canvas_camera_node.offset = Vector2(0,0)
+	canvas_camera_node.camera_zoom = Vector2(1,1)
+	canvas_camera_node.offset = Vector2(0,0)
+	

--- a/version_desktop/src/workspace/subviewportcontainer.gd
+++ b/version_desktop/src/workspace/subviewportcontainer.gd
@@ -30,7 +30,7 @@ func _input(event):
 			# zoom out
 			elif Input.is_key_pressed(KEY_MINUS):
 				canvas_camera.zoom_io(-canvas_camera.change_in_zoom, canvas_camera.offset)
-			# reset zoom and camera position
+			# reset zoom and camera position (implicitly signals scroll bars to reset)
 			elif Input.is_key_pressed(KEY_0):
 				canvas_camera.camera_zoom = Vector2(1,1)
 				canvas_camera.offset = Vector2(0,0)


### PR DESCRIPTION
- Arrow keys will change the camera position.
- Shift + Arrow key will reset the camera position on the axis of the key pressed.
- Ctrl + Arrow key can be used to navigate the UI for accessibility.

- Added a reset button which resets the camera position 